### PR TITLE
Applied minor revision changes to make webpage more dynamic

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -129,7 +129,6 @@ main{
     color: var(--quiz-options-text);
     list-style-position: inside;
 
-    width: 100%;
     margin-bottom: 1em;
 }
 
@@ -138,6 +137,7 @@ main{
     background-color: var(--quiz-options-color);
     border-radius: 0.5em;
 
+    word-wrap: break-word;
     padding: var(--quiz-options-padding);
     margin: 1em 0;
 }

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -3,7 +3,7 @@ var quiz_section = document.getElementById("quiz");
 var results_section = document.getElementById("quiz-results");
 var high_score_section = document.getElementById("high-scores");
 
-var totalTime = 10;
+var totalTime = 100;
 var secondsLeft;
 var timer;
 
@@ -135,6 +135,7 @@ function startCountdown(){
 }
 
 function displayQuiz() {
+    high_score_section.setAttribute("style", "display:none;");
     quiz_section.setAttribute("style", "display:flex;");
 
     var current_question = document.getElementById("quiz-question");
@@ -193,7 +194,7 @@ function checkAnswer(event) {
         showResults(secondsLeft);
         document.getElementById("time").innerHTML = secondsLeft;
     } else {
-        setTimeout(displayQuiz, 1000);
+        setTimeout(displayQuiz, 500);
     }
 }
 


### PR DESCRIPTION
CSS:
- Applied a word-wrap to the quiz options to prevent words from overflowing if the web browser is resized

JS:
- Set the attribute style of the high scores section to none inside the displayQuiz function. This is to prevent going to the high scores page if the user accidentally clicks on "view high scores" while the displayQuiz function is set to timeout before running the next question