### PR TITLE
Removed answer status when quiz is completed for next run

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -281,6 +281,7 @@ function goBack() {
     clearInterval(timer);
     question_index = 0;
     document.getElementById("time").innerHTML = "";
+    document.getElementById("answer-status").textContent = "";
 
     high_score_section.setAttribute("style", "display:none;");
     intro_section.setAttribute("style", "display:flex;");


### PR DESCRIPTION
Resets the answer status in the html file to be empty so there is no answer status displayed before the user answers the first question